### PR TITLE
fix: bump braintree version to 4.23.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,15 +43,18 @@ android {
 }
 
 dependencies {
+    def brantreeVersion = '4.23.1'
+    def googlePayVersion = '19.1.0'
+
     implementation 'com.braintreepayments.api:drop-in:6.4.0'
     // to perform 3DS verification
-    implementation 'com.braintreepayments.api:three-d-secure:4.19.0'
-    implementation 'com.braintreepayments.api:paypal:4.19.0'
+    implementation "com.braintreepayments.api:three-d-secure:$brantreeVersion"
+    implementation "com.braintreepayments.api:paypal:$brantreeVersion"
     // to offer Google Pay
-    implementation 'com.braintreepayments.api:google-pay:4.19.0'
+    implementation "com.braintreepayments.api:google-pay:$brantreeVersion"
     // to collect device data
-    implementation 'com.braintreepayments.api:data-collector:4.19.0'
-    implementation 'com.google.android.gms:play-services-wallet:16.0.1'
+    implementation "com.braintreepayments.api:data-collector:$brantreeVersion"
+    implementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.4.+'

--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeCustom.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeCustom.java
@@ -37,11 +37,11 @@ import com.google.android.gms.wallet.WalletConstants;
 import java.util.HashMap;
 
 
-public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalListener, ThreeDSecureListener, GooglePayListener {
+public class FlutterBraintreeCustom extends AppCompatActivity implements ThreeDSecureListener, GooglePayListener {
     private BraintreeClient mBraintreeClient;
     private ThreeDSecureClient threeDSecureClient;
     private GooglePayClient googlePayClient;
-    private PayPalClient payPalClient;
+//    private PayPalClient payPalClient;
     private String mTotalPrice;
     private static final String TAG = FlutterBraintreeCustom.class.getSimpleName();
     @Override
@@ -61,12 +61,12 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalL
             String type = intent.getStringExtra("type");
             Log.d(TAG, "type = "+type);
             switch (type) {
-                case "tokenizeCreditCard":
-                    tokenizeCreditCard();
-                    break;
-                case "requestPaypalNonce":
-                    requestPaypalNonce();
-                    break;
+//                case "tokenizeCreditCard":
+//                    tokenizeCreditCard();
+//                    break;
+//                case "requestPaypalNonce":
+//                    requestPaypalNonce();
+//                    break;
                 case "requestGooglePayNonce":
                     requestGooglePayNonce();
                     break;
@@ -101,6 +101,7 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalL
     }
 
     protected void requestPaypalNonce() {
+        /*
         payPalClient = new PayPalClient(this, mBraintreeClient);
         payPalClient.setListener(this);
 
@@ -132,6 +133,7 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalL
 
             payPalClient.tokenizePayPalAccount(this, payPalCheckoutRequest);
         }
+        */
     }
 
     protected void requestGooglePayNonce() {
@@ -168,34 +170,34 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalL
         setIntent(newIntent);
     }
 
-    @Override
-    public void onPayPalSuccess(@NonNull PayPalAccountNonce payPalAccountNonce) {
-        // send nonce to server
-        HashMap<String, Object> nonceMap = new HashMap<String, Object>();
-        nonceMap.put("nonce", payPalAccountNonce.getString());
-        nonceMap.put("isDefault", payPalAccountNonce.isDefault());
-        nonceMap.put("paypalPayerId", payPalAccountNonce.getPayerId());
-        Intent result = new Intent();
-        result.putExtra("type", "paymentMethodNonce");
-        result.putExtra("paymentMethodNonce", nonceMap);
-        setResult(RESULT_OK, result);
-        finish();
-    }
+//    @Override
+//    public void onPayPalSuccess(@NonNull PayPalAccountNonce payPalAccountNonce) {
+//        // send nonce to server
+//        HashMap<String, Object> nonceMap = new HashMap<String, Object>();
+//        nonceMap.put("nonce", payPalAccountNonce.getString());
+//        nonceMap.put("isDefault", payPalAccountNonce.isDefault());
+//        nonceMap.put("paypalPayerId", payPalAccountNonce.getPayerId());
+//        Intent result = new Intent();
+//        result.putExtra("type", "paymentMethodNonce");
+//        result.putExtra("paymentMethodNonce", nonceMap);
+//        setResult(RESULT_OK, result);
+//        finish();
+//    }
 
-    @Override
-    public void onPayPalFailure(@NonNull Exception error) {
-        if (error instanceof UserCanceledException) {
-            // user canceled
-            setResult(RESULT_CANCELED);
-            finish();
-        } else {
-            // handle error
-            Intent result = new Intent();
-            result.putExtra("error", error);
-            setResult(2, result);
-            finish();
-        }
-    }
+//    @Override
+//    public void onPayPalFailure(@NonNull Exception error) {
+//        if (error instanceof UserCanceledException) {
+//            // user canceled
+//            setResult(RESULT_CANCELED);
+//            finish();
+//        } else {
+//            // handle error
+//            Intent result = new Intent();
+//            result.putExtra("error", error);
+//            setResult(2, result);
+//            finish();
+//        }
+//    }
 
     @Override
     public void onGooglePaySuccess(@NonNull PaymentMethodNonce paymentMethodNonce) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,13 +25,18 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.flutter_braintree_example"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
``` Crash
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'com.braintreepayments.api.ThreeDSecureLookup com.braintreepayments.api.ThreeDSecureResult.b()' on a null object reference
       at com.braintreepayments.api.c6.v(ThreeDSecureClient.java:1)
       at com.braintreepayments.api.c6.e(ThreeDSecureClient.java:1)
       at com.braintreepayments.api.c6$e.a(ThreeDSecureClient.java:1)
       at com.braintreepayments.api.k1.d(ConfigurationLoader.java:10)
       at com.braintreepayments.api.g0$a.a(BraintreeClient.java:1)
       at com.braintreepayments.api.r.b(AuthorizationLoader.java:2)
       at com.braintreepayments.api.g0.n(BraintreeClient.java:1)
       at com.braintreepayments.api.g0.q(BraintreeClient.java:1)
       at com.braintreepayments.api.c6.i(ThreeDSecureClient.java:1)
       at com.braintreepayments.api.c6.h(ThreeDSecureClient.java:1)
       at com.example.flutter_braintree.FlutterBraintreeCustom$b.a(FlutterBraintreeCustom.java:1)
       at com.braintreepayments.api.a6$a.a(ThreeDSecureAPI.java:4)
       at com.braintreepayments.api.z3$c.run(HttpClient.java:1)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8775)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

related issue: https://github.com/braintree/braintree_android/pull/644

